### PR TITLE
API Token validity is always 24h

### DIFF
--- a/cmd/monoctl/create/api_token.go
+++ b/cmd/monoctl/create/api_token.go
@@ -58,7 +58,7 @@ func NewCreateAPITokenCmd() *cobra.Command {
 	flags.StringSliceVarP(&scopes, "scopes", "s", scopes, scopesUsage)
 	util.PanicOnError(cmd.MarkFlagRequired("scopes"))
 
-	flags.DurationP("validity", "v", validity, "Specify the validity period of the token.")
+	flags.DurationVarP(&validity, "validity", "v", validity, "Specify the validity period of the token.")
 
 	return cmd
 }


### PR DESCRIPTION
There is a bug in generating API tokens. The validity is always 24h no matter what flag was set.