### PR TITLE
Fix output on login breaking K8s authentication

### DIFF
--- a/cmd/monoctl/get/cluster_credentials.go
+++ b/cmd/monoctl/get/cluster_credentials.go
@@ -43,7 +43,7 @@ func NewGetClusterCredentials() *cobra.Command {
 			}
 
 			configManager := config.NewLoaderFromExplicitFile(flags.ExplicitFile)
-			return auth_util.RetryOnAuthFail(cmd.Context(), configManager, func(ctx context.Context) error {
+			return auth_util.RetryOnAuthFailSilently(cmd.Context(), configManager, func(ctx context.Context) error {
 				return usecases.NewGetClusterCredentialsUseCase(configManager, clusterName, clusterRole).Run(ctx)
 			})
 		},

--- a/internal/usecases/auth_test.go
+++ b/internal/usecases/auth_test.go
@@ -55,7 +55,7 @@ var _ = Describe("render auth page", func() {
 
 		confManager := config.NewLoaderFromConfig(conf)
 
-		aUc := NewAuthUsecase(confManager, false).(*authUseCase)
+		aUc := NewAuthUsecase(confManager, false, false).(*authUseCase)
 
 		version := "0.0.1-local"
 		commit := "1a2b3c"


### PR DESCRIPTION
monoctl outputs non json logs during the authentication flow which breaks the parsing of kubectl.

```
+-----------------------------------------------------------+
|monoctl has opened the browser for you to authenticate.    |
|It should show the log in screen of your identity provider |
|or the consent window if you are already logged in with it.|
+-----------------------------------------------------------+
Waiting for you to log in and give consent for OIDC flow...
You're successfully authenticated as '<OMITTED>.
---
{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{},"status":{"expirationTimestamp":"2022-03-21T12:09:18Z","token":"<OMITTED>"}}
```