### PR TITLE
Fix audit log get by user returns user actions

### DIFF
--- a/cmd/monoctl/get/audit_log_by_user.go
+++ b/cmd/monoctl/get/audit_log_by_user.go
@@ -43,7 +43,7 @@ func NewGetAuditLogByUserCmd() *cobra.Command {
 			configManager := config.NewLoaderFromExplicitFile(flags.ExplicitFile)
 
 			return auth_util.RetryOnAuthFail(cmd.Context(), configManager, func(ctx context.Context) error {
-				return usecases.NewGetAuditLogUserActionsUseCase(configManager.GetConfig(), getOutputOptions(), auditLogOptions, args[0]).Run(ctx)
+				return usecases.NewGetAuditLogByUserUseCase(configManager.GetConfig(), getOutputOptions(), auditLogOptions, args[0]).Run(ctx)
 			})
 		},
 	}


### PR DESCRIPTION
monoctl should return the audit log of events affected the user when `monoctl get audit-log user ...` is called however, it’s returning the user’s actions instead which is the behavior expected from `monoctl get audit-log user-actions ...`