### PR TITLE
Fix permission bug in monoctl

### DIFF
--- a/internal/usecases/create_kubeconfig.go
+++ b/internal/usecases/create_kubeconfig.go
@@ -128,7 +128,7 @@ func (u *createKubeConfigUseCase) setCluster(kubeConfig *kapi.Config, m8Cluster 
 }
 
 // setAuthInfo sets the auth information on kubeconfig
-func (u *createKubeConfigUseCase) setAuthInfo(kubeConfig *kapi.Config, authInfoName, clusterName string, clusterRole string) {
+func (u *createKubeConfigUseCase) setAuthInfo(kubeConfig *kapi.Config, authInfoName, clusterId string, clusterRole string) {
 	var ok bool
 	var kubeAuthInfo *kapi.AuthInfo
 	if kubeAuthInfo, ok = kubeConfig.AuthInfos[authInfoName]; !ok {
@@ -140,7 +140,7 @@ func (u *createKubeConfigUseCase) setAuthInfo(kubeConfig *kapi.Config, authInfoN
 		InstallHint: "Monoskope's commandline tool `monoctl` is required to authenticate to the current cluster.",
 		Command:     "monoctl",
 		Args: []string{
-			"get", "cluster-credentials", clusterName, string(clusterRole),
+			"get", "cluster-credentials", clusterId, string(clusterRole),
 		},
 		Env: make([]kapi.ExecEnvVar, 0),
 	}
@@ -187,7 +187,7 @@ func (u *createKubeConfigUseCase) run(ctx context.Context) error {
 			u.setContext(kubeConfig, clusterName, contextName, nsName, authInfoName)
 
 			// Set credentials on kubeconfig
-			u.setAuthInfo(kubeConfig, authInfoName, clusterName, clusterRole)
+			u.setAuthInfo(kubeConfig, authInfoName, clusterAccess.Cluster.Id, clusterRole)
 		}
 	}
 

--- a/internal/usecases/get_cluster_credentials.go
+++ b/internal/usecases/get_cluster_credentials.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"sync"
 
 	"github.com/finleap-connect/monoctl/internal/config"
 	mgrpc "github.com/finleap-connect/monoctl/internal/grpc"
@@ -119,31 +117,31 @@ func (u *getClusterCredentialsUseCase) run(ctx context.Context) error {
 }
 
 // getAllClustersAuthInformation gets a token per cluster to mimik cross cluster login (for now)
-func (u *getClusterCredentialsUseCase) getAllClustersAuthInformation(ctx context.Context) {
-	wg := &sync.WaitGroup{}
-	m8Clusters, _ := u.clusterServiceClient.GetAll(ctx, &api.GetAllRequest{IncludeDeleted: false})
-	for {
-		m8Cluster, err := m8Clusters.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			continue
-		}
+// func (u *getClusterCredentialsUseCase) getAllClustersAuthInformation(ctx context.Context) {
+// 	wg := &sync.WaitGroup{}
+// 	m8Clusters, _ := u.clusterServiceClient.GetAll(ctx, &api.GetAllRequest{IncludeDeleted: false})
+// 	for {
+// 		m8Cluster, err := m8Clusters.Recv()
+// 		if err == io.EOF {
+// 			break
+// 		}
+// 		if err != nil {
+// 			continue
+// 		}
 
-		clusterAuthInfo := u.config.GetClusterAuthInformation(m8Cluster.Name, u.config.AuthInformation.Username, u.clusterRole)
-		if clusterAuthInfo != nil && clusterAuthInfo.IsValidExact() {
-			continue
-		}
+// 		clusterAuthInfo := u.config.GetClusterAuthInformation(m8Cluster.Name, u.config.AuthInformation.Username, u.clusterRole)
+// 		if clusterAuthInfo != nil && clusterAuthInfo.IsValidExact() {
+// 			continue
+// 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, _ = u.requestClusterAuthInformation(ctx, m8Cluster.Id)
-		}()
-	}
-	wg.Wait()
-}
+// 		wg.Add(1)
+// 		go func() {
+// 			defer wg.Done()
+// 			_, _ = u.requestClusterAuthInformation(ctx, m8Cluster.Id)
+// 		}()
+// 	}
+// 	wg.Wait()
+// }
 
 func (u *getClusterCredentialsUseCase) requestClusterAuthInformation(ctx context.Context, clusterId string) (response *apiGateway.ClusterAuthTokenResponse, err error) {
 	// Get token from gateway

--- a/internal/usecases/get_cluster_credentials.go
+++ b/internal/usecases/get_cluster_credentials.go
@@ -24,11 +24,8 @@ import (
 	"github.com/finleap-connect/monoctl/internal/config"
 	mgrpc "github.com/finleap-connect/monoctl/internal/grpc"
 	api "github.com/finleap-connect/monoskope/pkg/api/domain"
-	"github.com/finleap-connect/monoskope/pkg/api/domain/projections"
 	apiGateway "github.com/finleap-connect/monoskope/pkg/api/gateway"
-	"github.com/finleap-connect/monoskope/pkg/k8s"
 	ggrpc "google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclientauth "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 )
@@ -39,15 +36,15 @@ type getClusterCredentialsUseCase struct {
 	configManager        *config.ClientConfigManager
 	clusterServiceClient api.ClusterClient
 	clusterAuthClient    apiGateway.ClusterAuthClient
-	clusterName          string
+	clusterId            string
 	clusterRole          string
 }
 
-func NewGetClusterCredentialsUseCase(configManager *config.ClientConfigManager, name, role string) UseCase {
+func NewGetClusterCredentialsUseCase(configManager *config.ClientConfigManager, clusterId, role string) UseCase {
 	useCase := &getClusterCredentialsUseCase{
 		useCaseBase:   NewUseCaseBase("get-cluster-credentials", configManager.GetConfig()),
 		configManager: configManager,
-		clusterName:   name,
+		clusterId:     clusterId,
 		clusterRole:   role,
 	}
 	return useCase
@@ -73,23 +70,20 @@ func (u *getClusterCredentialsUseCase) init(ctx context.Context) error {
 }
 
 func (u *getClusterCredentialsUseCase) run(ctx context.Context) error {
-	clusterAuthInfo := u.config.GetClusterAuthInformation(u.clusterName, u.config.AuthInformation.Username, u.clusterRole)
+	clusterAuthInfo := u.config.GetClusterAuthInformation(u.clusterId, u.config.AuthInformation.Username, u.clusterRole)
 	if clusterAuthInfo == nil || !clusterAuthInfo.IsValidExact() {
 		// Cache cluster credentials
-		m8cluster, err := u.clusterServiceClient.GetByName(ctx, wrapperspb.String(u.clusterName))
+		_, err := u.requestClusterAuthInformation(ctx, u.clusterId)
 		if err != nil {
 			return err
 		}
-		_, err = u.requestClusterAuthInformation(ctx, m8cluster)
-		if err != nil {
-			return err
-		}
-		clusterAuthInfo = u.config.GetClusterAuthInformation(u.clusterName, u.config.AuthInformation.Username, u.clusterRole)
+		clusterAuthInfo = u.config.GetClusterAuthInformation(u.clusterId, u.config.AuthInformation.Username, u.clusterRole)
 
 		// Cache all/other clusters credentials
-		if u.clusterRole == string(k8s.DefaultRole) {
-			u.getAllClustersAuthInformation(ctx)
-		}
+		// TODO FIX
+		// if u.clusterRole == string(k8s.DefaultRole) {
+		// 	u.getAllClustersAuthInformation(ctx)
+		// }
 
 		// Save credentials
 		err = u.configManager.SaveConfig()
@@ -145,16 +139,16 @@ func (u *getClusterCredentialsUseCase) getAllClustersAuthInformation(ctx context
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = u.requestClusterAuthInformation(ctx, m8Cluster)
+			_, _ = u.requestClusterAuthInformation(ctx, m8Cluster.Id)
 		}()
 	}
 	wg.Wait()
 }
 
-func (u *getClusterCredentialsUseCase) requestClusterAuthInformation(ctx context.Context, m8cluster *projections.Cluster) (response *apiGateway.ClusterAuthTokenResponse, err error) {
+func (u *getClusterCredentialsUseCase) requestClusterAuthInformation(ctx context.Context, clusterId string) (response *apiGateway.ClusterAuthTokenResponse, err error) {
 	// Get token from gateway
 	response, err = u.clusterAuthClient.GetAuthToken(ctx, &apiGateway.ClusterAuthTokenRequest{
-		ClusterId: m8cluster.Id,
+		ClusterId: clusterId,
 		Role:      u.clusterRole,
 	})
 	if err != nil {
@@ -162,7 +156,7 @@ func (u *getClusterCredentialsUseCase) requestClusterAuthInformation(ctx context
 	}
 
 	// Cache credentials
-	u.config.SetClusterAuthInformation(m8cluster.Name, u.config.AuthInformation.Username, u.clusterRole, response.AccessToken, response.Expiry.AsTime())
+	u.config.SetClusterAuthInformation(clusterId, u.config.AuthInformation.Username, u.clusterRole, response.AccessToken, response.Expiry.AsTime())
 
 	return
 }

--- a/internal/usecases/get_cluster_credentials_test.go
+++ b/internal/usecases/get_cluster_credentials_test.go
@@ -121,14 +121,15 @@ var _ = Describe("GetClusterCredentials", func() {
 		uc.clusterAuthClient = mockClusterAuthClient
 		uc.setInitialized()
 		err = uc.Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
 
 		uc = NewGetClusterCredentialsUseCase(confManager, expectedClusters[1].Id, expectedRole).(*getClusterCredentialsUseCase)
 		uc.clusterServiceClient = mockClusterClient
 		uc.clusterAuthClient = mockClusterAuthClient
 		uc.setInitialized()
 		err = uc.Run(ctx)
-
 		Expect(err).ToNot(HaveOccurred())
+
 		c := confManager.GetConfig()
 		Eventually(func(g Gomega) {
 			for _, expectedCluster := range expectedClusters {


### PR DESCRIPTION
The current state of monoctl still needs cluster access to generate auth tokens for K8s. This is not allowed for all users anymore for security reasons leading to people not able to login to K8s after the v0.4.0 upgrade of m8 control plane.

This fixes this issue.