### PR TITLE
Fix CSV exporter is skipping values

### DIFF
--- a/internal/output/table_factory.go
+++ b/internal/output/table_factory.go
@@ -117,8 +117,10 @@ func (tf *TableFactory) SetColumnFormatter(column string, columnFormatter func(i
 func (tf *TableFactory) ToTable() (*tablewriter.Table, error) {
 	if tf.exportFile != "" {
 		switch tf.exportFormat {
-		case CSV: return tf.newCsvTable()
-		default: return nil, errors.New("export format is not supported")
+		case CSV:
+			return tf.newCsvTable()
+		default:
+			return nil, errors.New("export format is not supported")
 		}
 	}
 	return tf.newStdoutTable()
@@ -154,7 +156,7 @@ func (tf *TableFactory) newCsvTable() (*tablewriter.Table, error) {
 	tbl.SetAlignment(tablewriter.ALIGN_LEFT)
 	tbl.SetHeaderLine(false)
 	tbl.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	tbl.SetAutoMergeCells(true)
+	tbl.SetAutoMergeCells(false)
 	tbl.SetColumnSeparator(",")
 	tbl.SetBorder(false)
 	tbl.SetHeader(tf.header)

--- a/internal/output/table_factory_test.go
+++ b/internal/output/table_factory_test.go
@@ -29,11 +29,12 @@ var _ = Describe("Internal/Util/TableFactory", func() {
 	Expect(tf).ToNot(BeNil())
 
 	tf.SetHeader([]string{"NAME", "VALUE"})
-	tf.SetData([][]interface{}{
+	data := [][]interface{}{
 		{"z", 1},
 		{"a", 26},
 		{"h", 8},
-	})
+	}
+	tf.SetData(data)
 
 	It("can create table with default sorting ascending", func() {
 		tableData := tf.formatData()
@@ -99,11 +100,15 @@ var _ = Describe("Internal/Util/TableFactory", func() {
 	})
 
 	It("can export table to file", func() {
+		data = append(data, data[0]) // to ensure duplicate data/lines are not merged/skipped
+		tf.SetData(data)
+
 		tmpFile, err := ioutil.TempFile(os.TempDir(), "m8-")
 		Expect(err).NotTo(HaveOccurred())
-		print(tmpFile.Name())
-		//defer os.Remove(tmpFile.Name())
+		defer os.Remove(tmpFile.Name())
 
+		// delete the file as it will be recreated when rendering
+		// and is not allowed to exist beforehand
 		err = os.Remove(tmpFile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -116,7 +121,7 @@ var _ = Describe("Internal/Util/TableFactory", func() {
 		tbl, err = tablewriter.NewCSV(os.Stdout, tmpFile.Name(), true)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(tbl.NumLines()).To(Equal(3))
+		Expect(tbl.NumLines()).To(Equal(len(data)))
 	})
 
 	It("can't export table if file exists", func() {


### PR DESCRIPTION
when exporting the audit log the CSV-exporter skips values (that already exist and were returned by M8).