### PR TITLE
Fix can not create cluster due to certificate validation error

### DIFF
--- a/cmd/monoctl/create/cluster.go
+++ b/cmd/monoctl/create/cluster.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/finleap-connect/monoctl/cmd/monoctl/flags"
 	"github.com/finleap-connect/monoctl/internal/config"
@@ -72,6 +73,7 @@ func NewCreateClusterCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to read CA certificates from '%s': %s", caCertBundleFile, err)
 			}
+			caCertBundle = []byte(strings.TrimSpace(string(caCertBundle)))
 
 			configManager := config.NewLoaderFromExplicitFile(flags.ExplicitFile)
 			return auth_util.RetryOnAuthFail(cmd.Context(), configManager, func(ctx context.Context) error {

--- a/cmd/monoctl/update/kubeconfig.go
+++ b/cmd/monoctl/update/kubeconfig.go
@@ -16,6 +16,7 @@ package update
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/finleap-connect/monoctl/cmd/monoctl/flags"
 	"github.com/finleap-connect/monoctl/internal/config"
@@ -43,6 +44,9 @@ You can also specify a custom file by utilising the file option (--file). In thi
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configManager := config.NewLoaderFromExplicitFile(flags.ExplicitFile)
+			if err := configManager.LoadConfig(); err != nil {
+				return fmt.Errorf("failed loading monoconfig: %w", err)
+			}
 			return auth_util.RetryOnAuthFail(cmd.Context(), configManager, func(ctx context.Context) error {
 				return usecases.NewUpdateKubeconfigUseCase(configManager, kubeConfigPath, overwrite).Run(ctx)
 			})

--- a/internal/usecases/update_kubeconfig.go
+++ b/internal/usecases/update_kubeconfig.go
@@ -160,8 +160,10 @@ func (u *UpdateKubeconfigUseCase) run(ctx context.Context) error {
 
 	// Load kubeconfig of current user
 	var kubeConfig *kapi.Config
-	u.kubeConfig.SetPath(u.config.KubeConfigPath)
 	u.kubeConfig.SetPath(u.kubeConfigPath) // overwrite path from m8Config if new one is specified by user
+	if len(u.kubeConfig.ConfigPath) == 0 {
+		u.kubeConfig.SetPath(u.config.KubeConfigPath)
+	}
 	if kubeConfig, err = u.kubeConfig.LoadConfig(); err != nil {
 		return err
 	}

--- a/internal/usecases/update_kubeconfig_test.go
+++ b/internal/usecases/update_kubeconfig_test.go
@@ -149,7 +149,7 @@ var _ = Describe("UpdateKubeconfig", func() {
 
 		mockClusterAccessClient := mdomain.NewMockClusterAccessClient(mockCtrl)
 
-		uc := NewUpdateKubeconfigUseCase(configManager, kubeTmpFile.Name(), true).(*UpdateKubeconfigUseCase)
+		uc := NewUpdateKubeconfigUseCase(configManager, "", true).(*UpdateKubeconfigUseCase)
 		uc.clusterAccessClient = mockClusterAccessClient
 		uc.kubeConfig = k8s.NewKubeConfig()
 		uc.setInitialized()


### PR DESCRIPTION
while creating a cluster, when passing a valid certificate ending with a trailing newline (or whatever that is not exactly `-----END CERTIFICATE-----`) M8 returns a validation error (as expected).

```shell
Error: rpc error: code = InvalidArgument desc = invalid CreateCluster.CaCertBundle: value does not have suffix "\x2D\x2D\x2D\x2D\x2D\x45\x4E\x44\x20\x43\x45\x52\x54\x49\x46\x49\x43\x41\x54\x45\x2D\x2D\x2D\x2D\x2D"
Usage:
  monoctl create cluster <KUBE_API_SERVER_ADDRESS> <CA_CERT_FILE> [flags]
```

**AC:**
- improve monoctl certificate handling to trim any leading/trailing spaces