### PR TITLE
Fix release binaries naming

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ archives:
   - replacements:
       darwin: osx
       windows: win
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
until `v0.5.0` we used dashes in the binaries name. This has to stay as is to ensure compatibility with other depending resources.