### PR TITLE
Fix release drafting

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
   - title: 'Features'
     labels:
@@ -18,6 +18,7 @@ categories:
       - 'chore'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-template: "v$MAJOR.$MINOR.$PATCH"
 version-resolver:
   major:
     labels:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,19 +16,28 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      # More assembly might be required: Docker logins, GPG, etc. It all depends
-      # on your needs.
-      - uses: goreleaser/goreleaser-action@v3
+      - name: set VERSION
+        run: echo "VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+      - name: Publish draft
+        uses: release-drafter/release-drafter@v5
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro':
+          version: ${{ env.VERSION }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Release
+        uses: goreleaser/goreleaser-action@v3
+        with:
           distribution: goreleaser
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,6 @@ archives:
       darwin: osx
       windows: win
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
the changes introduced in [v0.5.2](https://github.com/finleap-connect/monoctl/compare/v0.5.0...v0.5.2) broke release drafting. Compare [v0.5.2-rev3](https://github.com/finleap-connect/monoctl/releases/tag/v0.5.2-rev3) and [v0.5.0](https://github.com/finleap-connect/monoctl/releases/tag/v0.5.0) releases for a better picture.