### PR TITLE
change name template for archives to underscores

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ archives:
   - replacements:
       darwin: osx
       windows: win
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
change name template for archives to underscores to hopefully fix the brew release

Signed-off-by: Christian Hüning <christianhuening@users.noreply.github.com>